### PR TITLE
Enable Doze (Embient Display) and Burning Protection for it

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2095,11 +2095,11 @@
 
          Note that doze dreams are not subject to the same start conditions as ordinary dreams.
          Doze dreams will run whenever the power manager is in a dozing state. -->
-    <string name="config_dozeComponent" translatable="false"></string>
+    <string name="config_dozeComponent" translatable="false">com.android.systemui/com.android.systemui.doze.DozeService</string>
 
     <!-- If true, the doze component is not started until after the screen has been
          turned off and the screen off animation has been performed. -->
-    <bool name="config_dozeAfterScreenOffByDefault">false</bool>
+    <bool name="config_dozeAfterScreenOffByDefault">true</bool>
 
     <!-- Doze: should the TYPE_PICK_UP_GESTURE sensor be used as a pulse signal. -->
     <bool name="config_dozePulsePickup">false</bool>
@@ -2117,7 +2117,7 @@
 
     <!-- Control whether the always on display mode is enabled by default. This value will be used
          during initialization when the setting is still null. -->
-    <bool name="config_dozeAlwaysOnEnabled">true</bool>
+    <bool name="config_dozeAlwaysOnEnabled">false</bool>
 
     <!-- Whether the display blanks itself when transitioning from a doze to a non-doze state -->
     <bool name="config_displayBlanksAfterDoze">false</bool>
@@ -2900,7 +2900,7 @@
     <item name="config_screen_magnification_scaling_threshold" format="float" type="dimen">0.3</item>
 
     <!-- If true, the display will be shifted around in ambient mode. -->
-    <bool name="config_enableBurnInProtection">false</bool>
+    <bool name="config_enableBurnInProtection">true</bool>
 
     <!-- Specifies the maximum burn-in offset displacement from the center. If -1, no maximum value
          will be used. -->

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -245,7 +245,7 @@
     <!-- Doze: can we assume the pickup sensor includes a proximity check?
          This is ignored if doze_pickup_subtype_performs_proximity_check is not empty.
          @deprecated: use doze_pickup_subtype_performs_proximity_check instead.-->
-    <bool name="doze_pickup_performs_proximity_check">false</bool>
+    <bool name="doze_pickup_performs_proximity_check">true</bool>
 
     <!-- Doze: a list of pickup sensor subtypes that perform a proximity check before they trigger.
                If not empty, either * or !* must appear to specify the default.


### PR DESCRIPTION
This Enable a Doze (Ambient Display Mode). You can Enable it from Dispay Settings. Burning protection enable protection from burning display in Ambient mode.